### PR TITLE
Added support for filling lines that wrap, using weight, gravity and fill

### DIFF
--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -11,6 +11,9 @@
             f:horizontalSpacing="12dip"
             f:verticalSpacing="6dip"
             f:debugDraw="true"
+            f:fillLines="all"
+            f:weightDefault="1.0"
+            android:gravity="center_vertical|fill_horizontal"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
             android:paddingLeft="6dip"
@@ -18,11 +21,13 @@
             android:paddingRight="12dip"
             android:paddingBottom="12dip"
             android:id="@+id/flowLayout">
+
         <Button
                 android:layout_width="120dp"
                 android:layout_height="120dp"
                 android:text="@string/button_test"/>
         <Button
+                android:layout_gravity="bottom|fill_horizontal"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/button_test"/>
@@ -61,6 +66,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/button_test"/>
         <Button
+                f:layout_weight="0"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/button_test"/>
@@ -110,9 +116,9 @@
                 android:layout_height="wrap_content"
                 android:text="@string/button_test"/>
         <Button
+                f:layout_weight="5.0"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/button_test"/>
     </org.apmem.tools.layouts.FlowLayout>
 </LinearLayout>
-

--- a/libraries/layouts/src/main/res/values/attrs.xml
+++ b/libraries/layouts/src/main/res/values/attrs.xml
@@ -6,11 +6,21 @@
             <enum name="horizontal" value="0"/>
             <enum name="vertical" value="1"/>
         </attr>
-        <attr name="debugDraw" format="boolean" />
+        <attr name="fillLines" format="enum">
+            <enum name="none" value="0"/>
+            <enum name="exceptLast" value="1"/>
+            <enum name="all" value="2"/>
+        </attr>
+        <attr name="debugDraw" format="boolean"/>
+        <attr name="weightSum" format="float" />
+        <attr name="weightDefault" format="float" />
+        <attr name="android:gravity"/>
     </declare-styleable>
     <declare-styleable name="FlowLayout_LayoutParams">
         <attr name="layout_newLine" format="boolean"/>
         <attr name="layout_horizontalSpacing" format="dimension"/>
         <attr name="layout_verticalSpacing" format="dimension"/>
+        <attr name="layout_weight" format="float"/>
+        <attr name="android:layout_gravity"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Introduced a view attribute "fillLines" to allow FlowLayout to distribute left over space of a line that has wrapped among the child views of that line.

If "fillLines" is left at "none" (which is the default) FlowLayout will behave as normal, otherwise child views will receive left over space according their respective "weight" (works as in LinearLayout).

How each child view uses that extra space is determined by its "layout_gravity" (or the "gravity" of the parent FlowLayout); either it will be aligned within that space or stretched (with "fill_horizontal" or "fill_vertical") across that space.

This added feature was added with things such as toolbars in mind, where you may wish to be able to wrap views as needed but don't want any wasted space when wrapping; you could for example have a TextView for "search" fill up remaining space.

Just as with LinearLayout, deep child view hierarchies should be avoided when "fillLines" is enabled, as when active child views must be remeasured in a second pass in order to support the "weight" attribute.

![device-2014-05-13-135723](https://cloud.githubusercontent.com/assets/689840/2956768/d8afa0ae-da95-11e3-9f15-d3b3ae2e6f7b.png)
