### PR TITLE
The layout does not respect child margins

### DIFF
--- a/app/src/main/java/org/apmem/tools/example/MyActivity.java
+++ b/app/src/main/java/org/apmem/tools/example/MyActivity.java
@@ -2,96 +2,55 @@ package org.apmem.tools.example;
 
 import android.app.Activity;
 import android.os.Bundle;
-import android.view.Gravity;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
 import org.apmem.tools.layouts.FlowLayout;
 
 public class MyActivity extends Activity {
-    /**
-     * Called when the activity is first created.
-     */
+
+    private FlowLayout flow;
+    private Button unwrappedButton;
+    private Button wrappedButton;
+    private EditText edit;
+
+    private void bindViews() {
+        flow = (FlowLayout) findViewById(R.id.flow_container);
+        unwrappedButton = (Button) findViewById(R.id.button_unwrapped);
+        wrappedButton = (Button) findViewById(R.id.button_wrapped);
+        edit = (EditText) findViewById(R.id.edit_text);
+    }
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
 
-        final FlowLayout layout = (FlowLayout) this.findViewById(R.id.flowLayout);
+        bindViews();
 
-        final Button buttonOrientation = new Button(this);
-        buttonOrientation.setLayoutParams(new FlowLayout.LayoutParams(100, 100));
-        buttonOrientation.setTextSize(8);
-        buttonOrientation.setText("Switch Orientation (Current: Horizontal)");
-        buttonOrientation.setOnClickListener(new View.OnClickListener() {
+        unwrappedButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                layout.setOrientation(1 - layout.getOrientation());
-                buttonOrientation.setText(layout.getOrientation() == FlowLayout.HORIZONTAL ?
-                        "Switch Orientation (Current: Horizontal)" :
-                        "Switch Orientation (Current: Vertical)");
+                View child = LayoutInflater.from(getApplicationContext()).inflate(
+                        R.layout.child, flow, false);
+                TextView text = (TextView) child.findViewById(R.id.child_text);
+                text.setText(edit.getText());
+                flow.addView(child);
             }
         });
-        layout.addView(buttonOrientation, 0);
-
-        final Button buttonGravity = new Button(this);
-        buttonGravity.setLayoutParams(new FlowLayout.LayoutParams(100, 100));
-        buttonGravity.setTextSize(8);
-        buttonGravity.setText("Switch Gravity (Current: FILL)");
-        buttonGravity.setOnClickListener(new View.OnClickListener() {
+        wrappedButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                switch (layout.getGravity()) {
-                    case Gravity.LEFT | Gravity.TOP:
-                        layout.setGravity(Gravity.FILL);
-                        buttonGravity.setText("Switch Gravity (Current: FILL)");
-                        break;
-                    case Gravity.FILL:
-                        layout.setGravity(Gravity.CENTER);
-                        buttonGravity.setText("Switch Gravity (Current: CENTER)");
-                        break;
-                    case Gravity.CENTER:
-                        layout.setGravity(Gravity.RIGHT | Gravity.BOTTOM);
-                        buttonGravity.setText("Switch Gravity (Current: RIGHT | BOTTOM)");
-                        break;
-                    case Gravity.RIGHT | Gravity.BOTTOM:
-                        layout.setGravity(Gravity.LEFT | Gravity.TOP);
-                        buttonGravity.setText("Switch Gravity (Current: LEFT | TOP)");
-                        break;
-                }
+                View child = LayoutInflater.from(getApplicationContext()).inflate(
+                        R.layout.child_wrapped, flow, false);
+                TextView text = (TextView) child.findViewById(R.id.child_text);
+                text.setText(edit.getText());
+                flow.addView(child);
             }
         });
-        layout.addView(buttonGravity, 0);
 
-        final Button buttonLayoutDirection = new Button(this);
-        buttonLayoutDirection.setLayoutParams(new FlowLayout.LayoutParams(100, 100));
-        buttonLayoutDirection.setTextSize(8);
-        buttonLayoutDirection.setText("Switch LayoutDirection (Current: LTR)");
-        buttonLayoutDirection.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                layout.setLayoutDirection(1 - layout.getLayoutDirection());
-                buttonLayoutDirection.setText(layout.getLayoutDirection() == FlowLayout.LAYOUT_DIRECTION_LTR ?
-                        "Switch LayoutDirection (Current: LTR)" :
-                        "Switch LayoutDirection (Current: RTL)");
-            }
-
-        });
-        layout.addView(buttonLayoutDirection, 0);
-
-        final Button buttonDebug = new Button(this);
-        buttonDebug.setLayoutParams(new FlowLayout.LayoutParams(100, 100));
-        buttonDebug.setTextSize(8);
-        buttonDebug.setText("Switch Debug (Current: true)");
-        buttonDebug.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                layout.setDebugDraw(!layout.isDebugDraw());
-                buttonDebug.setText(layout.isDebugDraw() ?
-                        "Switch LayoutDirection (Current: true)" :
-                        "Switch LayoutDirection (Current: false)");
-            }
-
-        });
-        layout.addView(buttonDebug, 0);
     }
 }

--- a/app/src/main/res/layout/child.xml
+++ b/app/src/main/res/layout/child.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="@dimen/child_margin"
+    android:layout_marginRight="@dimen/child_margin"
+    android:gravity="center_vertical"
+    >
+
+    <TextView
+        android:id="@+id/child_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:singleLine="true"
+        android:textSize="@dimen/text_size"
+        android:gravity="center_vertical"
+        tools:text="test"
+        />
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@android:drawable/ic_menu_save"
+    />
+</LinearLayout>

--- a/app/src/main/res/layout/child_wrapped.xml
+++ b/app/src/main/res/layout/child_wrapped.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+    <include
+        layout="@layout/child"
+        />
+</FrameLayout>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -1,83 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-    <org.apmem.tools.layouts.FlowLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:f="http://schemas.android.com/apk/res-auto"
-            android:orientation="horizontal"
-            f:debugDraw="true"
-            f:weightDefault="1.0"
-            f:layoutDirection="ltr"
-            android:gravity="fill"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:paddingLeft="6dip"
-            android:paddingTop="6dip"
-            android:paddingRight="12dip"
-            android:paddingBottom="12dip"
-            android:background="@android:color/black"
-            android:id="@+id/flowLayout">
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:f="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="50dp"
+    android:layout_marginRight="50dp"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    >
 
-        <Button
-                android:layout_width="120dp"
-                android:layout_height="120dp"
-                android:text="@string/button_test"/>
-        <Button
-                android:layout_gravity="bottom|fill_horizontal"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_test"/>
-        <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_test"/>
-        <Button
-                android:layout_marginRight="32dip"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_horizontalMargin"/>
-        <Button
-                android:layout_marginBottom="32dip"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_verticalMargin"/>
-        <Button
-                android:layout_marginLeft="32dip"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_horizontalMargin"/>
-        <Button
-                android:layout_marginTop="32dip"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_verticalMargin"/>
-        <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_longTest"/>
-        <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_test"/>
-        <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_test"/>
-        <Button
-                f:layout_weight="0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_test"/>
-        <Button
-                f:layout_newLine="true"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_newLine"/>
-        <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_test"/>
-        <TextView
-                f:layout_weight="1000.0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
+    <org.apmem.tools.layouts.FlowLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="fill_horizontal|center_vertical"
+        f:layoutDirection="ltr"
+        android:id="@+id/flow_container"
+        >
+
     </org.apmem.tools.layouts.FlowLayout>
+
+    <EditText
+        android:id="@+id/edit_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/text_size"
+        android:hint="Enter text"
+        />
+
+    <Button
+        android:id="@+id/button_unwrapped"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Add unwrapped"
+        />
+    <Button
+        android:id="@+id/button_wrapped"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Add wrapped"
+        />
+</LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="child_margin">20dp</dimen>
+    <dimen name="text_size">20sp</dimen>
+</resources>


### PR DESCRIPTION
Not actually a pull request, but would be easier for you to observe the bug that way, just modified the demo app a bit.
So, there is kinda minimal not-working example app, you can enter the text in the field and then add it via one of two buttons.
The "Add unwrapped" button adds my layout (see `R.layout.child`) to the FlowLayoyt as is, whereas "Add wrapped" adds this layout wrapped in a dummy FrameLayout (see `R.layout.child_wrapped`)
And [here's my (annotated) screenshot](https://dl.dropboxusercontent.com/u/8487092/flow-layout-margins.png). The first child layout was added via the "Add unwrapped" button, the second via the "Add wrapped" button, the first's layout right margin is not respected, whereas the second's margin is respected (since wrapping FrameLayout has no margins at all).
You have any idea what am I doing wrong, or it is indeed a bug? I don't have much time right now, so I could live with a wrapping layout solution for a while, but if it is a bug, I could even try to fix that later.
Thanks in advance.
