### PR TITLE
Set line gravity based on childs with spacing

### DIFF
--- a/libraries/layouts/src/main/java/org/apmem/tools/layouts/FlowLayout.java
+++ b/libraries/layouts/src/main/java/org/apmem/tools/layouts/FlowLayout.java
@@ -207,7 +207,7 @@ public class FlowLayout extends ViewGroup {
             int gravity = this.getGravity();
             int extraThickness = Math.round(excessThickness * weight / totalWeight);
 
-            final int childLength = child.getLineLength();
+            final int childLength = child.getLineLengthWithSpacing();
             final int childThickness = child.getLineThickness();
 
             Rect container = new Rect();

--- a/libraries/layouts/src/main/java/org/apmem/tools/layouts/LineDefinition.java
+++ b/libraries/layouts/src/main/java/org/apmem/tools/layouts/LineDefinition.java
@@ -60,6 +60,10 @@ class LineDefinition {
         return lineLength;
     }
 
+    public int getLineLengthWithSpacing() {
+        return lineLengthWithSpacing;
+    }
+
     public int getLineStartLength() {
         return lineStartLength;
     }


### PR DESCRIPTION
When measuring the left offset for horizontally centering a view, the margins of the children were not accounted for (see https://github.com/ApmeM/android-flowlayout/pull/47 for an example). This Pull Request fixes this issue. I did not check how this would work for vertical centering.