### PR TITLE
Update rest of excess length/thickness

### DIFF
--- a/libraries/layouts/src/main/java/org/apmem/tools/layouts/logic/CommonLogic.java
+++ b/libraries/layouts/src/main/java/org/apmem/tools/layouts/logic/CommonLogic.java
@@ -34,7 +34,7 @@ public class CommonLogic {
             return;
         }
 
-        final int totalWeight = linesCount;
+        int remainderWeight = linesCount;
         LineDefinition lastLine = lines.get(linesCount - 1);
         int excessThickness = realControlThickness - (lastLine.getLineThickness() + lastLine.getLineStartThickness());
 
@@ -47,7 +47,10 @@ public class CommonLogic {
             final LineDefinition child = lines.get(i);
             int weight = 1;
             int gravity = getGravity(null, config);
-            int extraThickness = Math.round(excessThickness * weight / totalWeight);
+            int extraThickness = Math.round(excessThickness * weight / remainderWeight);
+
+            excessThickness -= extraThickness;
+            remainderWeight -= weight;
 
             final int childLength = child.getLineLength();
             final int childThickness = child.getLineThickness();
@@ -78,25 +81,29 @@ public class CommonLogic {
             return;
         }
 
-        float totalWeight = 0;
+        float remainderWeight = 0;
         for (int i = 0; i < viewCount; i++) {
             final ViewDefinition child = views.get(i);
-            totalWeight += getWeight(child, config);
+            remainderWeight += getWeight(child, config);
         }
+        final boolean weightBased = remainderWeight > 0;
 
         ViewDefinition lastChild = views.get(viewCount - 1);
-        int excessLength = line.getLineLength() - (lastChild.getLength() + lastChild.getSpacingLength() + lastChild.getInlineStartLength());
+        int excessLengthRemaining = line.getLineLength() - (lastChild.getLength() + lastChild.getSpacingLength() +
+                lastChild.getInlineStartLength());
         int excessOffset = 0;
         for (int i = 0; i < viewCount; i++) {
             final ViewDefinition child = views.get(i);
             float weight = getWeight(child, config);
             int gravity = getGravity(child, config);
             int extraLength;
-            if (totalWeight == 0) {
-                extraLength = excessLength / viewCount;
+            if (!weightBased) {
+                extraLength = excessLengthRemaining / (viewCount - i);
             } else {
-                extraLength = Math.round(excessLength * weight / totalWeight);
+                extraLength = Math.round(excessLengthRemaining * weight / remainderWeight);
+                remainderWeight -= weight;
             }
+            excessLengthRemaining -= extraLength;
 
             final int childLength = child.getLength() + child.getSpacingLength();
             final int childThickness = child.getThickness() + child.getSpacingThickness();


### PR DESCRIPTION
Just dividing the line excess length (or thickness) with the number of children (or lines) produces rounding errors, leaving unallocated pixels in some cases. So instead, update the remainder and divide again with the rest of the children. Eventually the division will be with 1, making the last child take all the then available pixels and leaving no pixels unallocated.
